### PR TITLE
Change datafile metadata YAML field to output None if empty

### DIFF
--- a/ime/tests/test_image_parser.py
+++ b/ime/tests/test_image_parser.py
@@ -3,7 +3,6 @@ from ime.parser.image_parser import ImageProcessor
 from pathlib import Path
 import logging
 
-import imagej
 import jpype
 import scyjava
 import jpype.imports

--- a/ime/tests/test_loadYaml.py
+++ b/ime/tests/test_loadYaml.py
@@ -35,3 +35,28 @@ def test_loadYaml():
                     obj,
                 )
     assert len(metadata.projects) == 2
+
+def test_datafile_metadata_saved_as_none_if_empty(tmp_path: Path) -> None:
+    """Tests whether for datafile, if there is no metadata, it is saved as a None, rather 
+    than an empty dict. This is expected by the ingestion script.
+
+    Args:
+        metadata (IngestionMetadata): The ingestion metadata.
+    """
+    # Create a datafile in the same tmp path.
+    tmp_datafile = tmp_path / "data.txt"
+    tmp_datafile.touch()
+    # Create a new metadata collection, with the datafile.
+    metadata = IngestionMetadata()
+    df = Datafile()
+    df.path_abs = tmp_datafile
+    df.metadata = {}
+    metadata.datafiles.append(df)
+    new_path = str(tmp_path / "new.yaml")
+    # Save the ingestion file.
+    metadata.to_file(new_path)
+    # Load the newly saved ingestion file and find the datafile again.
+    new_metadata = IngestionMetadata.from_file(new_path)
+    assert len(new_metadata.datafiles) == 1
+    # Check that the metadata is now None.
+    assert new_metadata.datafiles[0].metadata is None

--- a/ime/tests/test_metadata_tab.py
+++ b/ime/tests/test_metadata_tab.py
@@ -17,6 +17,7 @@ def table(widget: MetadataTab):
 def test_create_table_entries(qtbot: QtBot, metadata: IngestionMetadata, widget: MetadataTab, table: QTableWidget):
     assert table.rowCount() == 0
     exp = metadata.experiments[0]
+    assert exp.metadata is not None
     nrows = len(exp.metadata)
     widget.update_metadata_object(exp)
     qtbot.add_widget(widget)
@@ -46,6 +47,7 @@ def test_update_metadata_object_replaces_table_entries(qtbot: QtBot, metadata: I
 def test_update_metadata_key_changes_object(qtbot: QtBot, metadata: IngestionMetadata, widget: MetadataTab, table: QTableWidget):
     exp = metadata.experiments[0]
     widget.update_metadata_object(exp)
+    assert exp.metadata is not None
     nrows = len(exp.metadata)
     widget.show()
     qtbot.wait_exposed(widget)
@@ -64,6 +66,7 @@ def test_update_metadata_key_changes_object(qtbot: QtBot, metadata: IngestionMet
 def test_update_metadata_object_updates_value(qtbot: QtBot, metadata: IngestionMetadata, widget: MetadataTab, table: QTableWidget):
     exp = metadata.experiments[0]
     proj = metadata.projects[0]
+    assert proj.metadata is not None
     widget.update_metadata_object(exp)
     widget.show()
     qtbot.wait_exposed(widget)
@@ -76,6 +79,7 @@ def test_update_metadata_object_updates_value(qtbot: QtBot, metadata: IngestionM
 
 def test_delete_metadata_rows(qtbot: QtBot, metadata: IngestionMetadata, widget: MetadataTab, table: QTableWidget):
     exp = metadata.experiments[0]
+    assert exp.metadata is not None
     widget.update_metadata_object(exp)
     widget.show()
     qtbot.wait_exposed(widget)

--- a/ime/widgets/metadata_tab.py
+++ b/ime/widgets/metadata_tab.py
@@ -5,14 +5,14 @@ from ime.bindable import IBindableInput
 from ime.ui.ui_metadata_tab import Ui_MetadataTab
 from PyQt5.QtWidgets import QHBoxLayout, QTableWidgetItem, QWidget, QLineEdit
 from PyQt5.QtCore import pyqtSignal, Qt
-from ime.models import IMetadata
+from ime.models import MyTardisObject
 import logging
 
 from ime.utils import setup_header_layout
 
 class MetadataTab(QWidget, IBindableInput):
     """A tab widget for displaying and editing metadata information for an object."""
-    metadata_object: IMetadata
+    metadata_object: MyTardisObject
     ui: Ui_MetadataTab
 
     def __init__(self, parent=None):
@@ -34,6 +34,8 @@ class MetadataTab(QWidget, IBindableInput):
 
     def handleNotes_changed(self) -> None:
         """Handler method for notes changed."""
+        if self.metadata_object.metadata is None:
+            self.metadata_object.metadata = {}
         self.metadata_object.metadata['Notes'] = self.ui.notes_textedit.toPlainText()
 
     def add_insert_metadata_row(self) -> None:
@@ -96,6 +98,8 @@ class MetadataTab(QWidget, IBindableInput):
             col (int): The column index of the changed cell.
         """
         table = self.ui.metadata_table
+        if self.metadata_object.metadata is None:
+            self.metadata_object.metadata = {}
         metadata = self.metadata_object.metadata
         cell = table.item(row, col)
         cell_val = cell.text()
@@ -156,14 +160,15 @@ class MetadataTab(QWidget, IBindableInput):
                 # Skip deleting the empty row.
                 continue
             key = table.item(row, 0).text()
-            self.metadata_object.metadata.pop(key)
+            if self.metadata_object.metadata is not None:
+                self.metadata_object.metadata.pop(key)
             table.removeRow(row)
 
-    def update_metadata_object(self, metadata_obj: IMetadata) -> None:
+    def update_metadata_object(self, metadata_obj: MyTardisObject) -> None:
         """Updates the object this tab is modifying.
 
         Args:
-            metadata_obj (IMetadata): The metadata object to update the tab with.
+            metadata_obj (MyTardisObject): The metadata object to update the tab with.
         """
         # Block table change signals while object is being updated.
         with QSignalBlocker(self.ui.metadata_table):
@@ -173,6 +178,8 @@ class MetadataTab(QWidget, IBindableInput):
             table.clearContents()
             table.setRowCount(0)
             # Then, populate table with new items 
+            if metadata_obj.metadata is None:
+                return
             metadata = metadata_obj.metadata
             num_new = len(metadata)
             if "Notes" in metadata:


### PR DESCRIPTION
This PR adds a feature that checks if datafile metadata is empty. If so, replace them with a `None` in the YAML output. This is because the ingestion process expects either a None for no metadata, or a dictionary with valid metadata entries.

This PR also removes the IMetadata interface, and instead adds fields to each MyTardis object. This is so we could add custom behaviour for `Datafile` serialisation. The `metadata` field is now `Optional` to allow `None` as the value, with the `MetadataTab` component changed to handle `None`s.